### PR TITLE
proxy() for window resize event handler

### DIFF
--- a/demos/selectmenu/destroy_bug.html
+++ b/demos/selectmenu/destroy_bug.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+	<title>Test</title>
+	<script type="text/javascript" src="../../jquery-1.4.4.js"></script>
+	<script type="text/javascript" src="../../ui/jquery.ui.core.js"></script>
+	<script type="text/javascript" src="../../ui/jquery.ui.widget.js"></script>
+	<script type="text/javascript" src="../../ui/jquery.ui.position.js"></script>
+	
+	<script type="text/javascript" src="../../ui/jquery.ui.selectmenu.js"></script>
+	<script type="text/javascript">
+		$(document).ready(
+			function() {
+				$("#selectmenu").selectmenu();
+		
+				$("#destroy").live("click", function(){
+					$("#selectmenu").selectmenu("destroy");
+				})
+			}
+		);		
+	</script>
+</head>
+
+<body>
+	
+	<button id="destroy">Destroy Menu</button>
+	<br/>
+	
+	<select id="selectmenu">
+		<option value="1">Option 1</option>
+		<option value="2">Option 2</option>
+		<option value="3">Option 3</option>
+		<option value="4">Option 4</option>
+	</select>
+</body>
+</html>

--- a/ui/jquery.ui.selectmenu.js
+++ b/ui/jquery.ui.selectmenu.js
@@ -333,14 +333,12 @@ $.widget("ui.selectmenu", {
 		this.index(this._selectedIndex());
 		
 		// needed when selectmenu is placed at the very bottom / top of the page
-        window.setTimeout(function() {
+       window.setTimeout(function() {
             self._refreshPosition();
         }, 200);
 		
 		// needed when window is resized
-		$(window).resize(function(){
-			self._refreshPosition();
-		});		
+       $(window).resize(jQuery.proxy(self._refreshPosition,this));
 	},
 	destroy: function() {
 		this.element.removeData(this.widgetName)
@@ -352,6 +350,9 @@ $.widget("ui.selectmenu", {
 		$('label[for='+this.newelement.attr('id')+']')
 			.attr('for',this.element.attr('id'))
 			.unbind('click');
+		
+		$(window).unbind('resize', this._refreshPosition);
+
 		this.newelement.remove();
 		// FIXME option.wrapper needs
 		this.list.remove();


### PR DESCRIPTION
Destroy method does not remove the window resize event handler.  

Destroying a selectmenu and then resizing the window causes a "setting a property that has only a getter" error to be thrown from jQuery.ui.
