### PR TITLE
Disabling individual options via API

### DIFF
--- a/themes/base/jquery.ui.selectmenu.css
+++ b/themes/base/jquery.ui.selectmenu.css
@@ -14,6 +14,9 @@
 .ui-selectmenu-status { line-height: 1.4em; }
 .ui-selectmenu-open li.ui-selectmenu-item-focus a {  }
 .ui-selectmenu-open li.ui-selectmenu-item-selected { }
+/* Disabled option styling */
+.ui-selectmenu-menu li.disabled { border: 1px solid transparent; }
+.ui-selectmenu-menu li.disabled a { cursor: default; color: #A9ACAF; background: #EBEBEC; }
 .ui-selectmenu-menu li span,.ui-selectmenu-status span { display:block; margin-bottom: .2em; }
 .ui-selectmenu-menu li .ui-selectmenu-item-header { font-weight: bold; }
 .ui-selectmenu-menu li .ui-selectmenu-item-content {  }


### PR DESCRIPTION
adding in the ability to disable an option by passing in the particular index of the option you want to disable. This change is backwards compatible, so if you don't want to use this feature it will not affect any of your existing code or coding practices.

Enhancements include:
- Ability to disable an option
- Key events correctly skip disabled option
- Styling for disabled options
- Change and select events ignore disabled option
- index function correctly ignores disabled option
- disable and enable function call _setOption, keeping code modular

Example for disabling an option:
    $('#my-selectmenu').selectmenu('disable',0)
    //disables the first option in the option list

Enhancements which should be added in the future:
- keep a consistent state between the original menu and the generated menu
- Disable options which were disabled through HTML
