### PR TITLE
Allows extension

### DIFF
--- a/ui/jquery.ui.selectmenu.js
+++ b/ui/jquery.ui.selectmenu.js
@@ -307,6 +307,18 @@ $.widget("ui.selectmenu", {
       item.appendTo(this.list);
     }
   },
+  
+  _updateListWidth: function() {
+		// original selectmenu width
+		var o = this.options, selectWidth = this.element.width();
+
+		// set menu width to either menuWidth option value, width option value, or select width
+		if (o.style == 'dropdown') {
+			this.list.width(o.menuWidth ? o.menuWidth : (o.width ? o.width : selectWidth));
+		} else {
+			this.list.width(o.menuWidth ? o.menuWidth : (o.width ? o.width - o.handleWidth : selectWidth - o.handleWidth));
+		}
+  },
 
 	_init: function() {
 		var self = this, o = this.options;
@@ -403,15 +415,7 @@ $.widget("ui.selectmenu", {
 			this.newelement.add(this.list).addClass(transferClasses);
 		}
 
-		// original selectmenu width
-		var selectWidth = this.element.width();
-
-		// set menu width to either menuWidth option value, width option value, or select width 
-		if (o.style == 'dropdown') { 
-			this.list.width(o.menuWidth ? o.menuWidth : (o.width ? o.width : selectWidth)); 
-		} else { 
-			this.list.width(o.menuWidth ? o.menuWidth : (o.width ? o.width - o.handleWidth : selectWidth - o.handleWidth)); 
-		}
+    this._updateListWidth();
 
 		// calculate default max height
 		if (o.maxHeight) {

--- a/ui/jquery.ui.selectmenu.js
+++ b/ui/jquery.ui.selectmenu.js
@@ -232,6 +232,23 @@ $.widget("ui.selectmenu", {
 		$(window).bind( "resize.selectmenu", $.proxy( self._refreshPosition, this ) );
 	},
 
+  /**
+   * Get data for an option element
+   * These data will be stored in selectOptionData array
+   * (allows for overriding this method)
+   */
+  _getOptionData: function(option) {
+    return {
+      value: $(option).attr('value'),
+      text: this._formatText($(option).text()),
+      selected: $(option).attr('selected'),
+      classes: $(option).attr('class'),
+      typeahead: $(option).attr('typeahead'),
+      parentOptGroup: $(option).parent('optgroup').attr('label'),
+      bgImage: this.options.bgImage.call($(option))
+    };
+  },
+
 	_init: function() {
 		var self = this, o = this.options;
 		
@@ -240,15 +257,7 @@ $.widget("ui.selectmenu", {
 		this.element
 			.find('option')
 			.each(function() {
-				selectOptionData.push({
-					value: $(this).attr('value'),
-					text: self._formatText($(this).text()),
-					selected: $(this).attr('selected'),
-					classes: $(this).attr('class'),
-					typeahead: $(this).attr('typeahead'),
-					parentOptGroup: $(this).parent('optgroup').attr('label'),
-					bgImage: o.bgImage.call($(this))
-				});
+				selectOptionData.push(self._getOptionData(this));
 			});		
 				
 		// active state class is only used in popup style

--- a/ui/jquery.ui.selectmenu.js
+++ b/ui/jquery.ui.selectmenu.js
@@ -15,6 +15,10 @@ $.widget("ui.selectmenu", {
 	getter: "value",
 	version: "1.8",
 	eventPrefix: "selectmenu",
+  listContainerSelector: 'ul',
+  listContainerTag: 'ul',
+  listItemSelector: 'li',
+  listItemTag: 'li',
 	options: {
 		transferClasses: true,
 		typeAhead: "sequential",
@@ -209,7 +213,7 @@ $.widget("ui.selectmenu", {
 					case $.ui.keyCode.ENTER:
 					case $.ui.keyCode.SPACE:
 						self.close(event, true);
-						$(event.target).parents('li:eq(0)').trigger('mouseup');
+						$(event.target).parents(this.listItemSelector + ':eq(0)').trigger('mouseup');
 						break;		
 					case $.ui.keyCode.TAB:
 						ret = true;
@@ -237,7 +241,7 @@ $.widget("ui.selectmenu", {
    * @return HTMLElement
    */
   _createListContainer: function() {
-    return $('<ul class="' + this.widgetBaseClass + '-menu ui-widget ui-widget-content" aria-hidden="true" role="listbox" aria-labelledby="' + this.ids[0] + '" id="' + this.ids[1] + '"></ul>');
+    return $('<' + this.listContainerTag + ' class="' + this.widgetBaseClass + '-menu ui-widget ui-widget-content" aria-hidden="true" role="listbox" aria-labelledby="' + this.ids[0] + '" id="' + this.ids[1] + '" />');
   },
 
   /**
@@ -268,7 +272,7 @@ $.widget("ui.selectmenu", {
    * @return HTMLElement
    */
   _createListItem: function(optionData) {
-    return $('<li role="presentation"><a href="#" tabindex="-1" role="option" aria-selected="false"'+ (optionData.typeahead ? ' typeahead="' + optionData.typeahead + '"' : '' ) + '>'+ optionData.text +'</a></li>')
+    return $('<' + this.listItemTag + ' role="presentation"><a href="#" tabindex="-1" role="option" aria-selected="false"'+ (optionData.typeahead ? ' typeahead="' + optionData.typeahead + '"' : '' ) + '>'+ optionData.text +'</a></' + this.listItemTag + '>')
   },
 
   /**
@@ -281,12 +285,12 @@ $.widget("ui.selectmenu", {
     if (optionData.parentOptGroup) {
       // whitespace in the optgroupname must be replaced, otherwise the li of existing optgroups are never found
       var optGroupName = this.widgetBaseClass + '-group-' + optionData.parentOptGroup.replace(/[^a-zA-Z0-9]/g, "");
-      if (this.list.find('li.' + optGroupName).size()) {
-        this.list.find('li.' + optGroupName + ':last ul').append(item);
+      if (this.list.find(this.listItemSelector + '.' + optGroupName).size()) {
+        this.list.find(this.listItemSelector + '.' + optGroupName + ':last ' + this.listContainerSelector).append(item);
       } else {
-        $('<li role="presentation" class="' + self.widgetBaseClass + '-group ' + optGroupName + '"><span class="' + self.widgetBaseClass + '-group-label">' + optionData.parentOptGroup + '</span><ul></ul></li>')
+        $('<' + this.listItemTag + ' role="presentation" class="' + self.widgetBaseClass + '-group ' + optGroupName + '"><span class="' + self.widgetBaseClass + '-group-label">' + optionData.parentOptGroup + '</span><' + this.listContainerTag + ' /></' + this.listItemTag + '>')
           .appendTo(this.list)
-          .find('ul')
+          .find(this.listContainerSelector)
           .append(item);
       }
     } else {
@@ -375,9 +379,9 @@ $.widget("ui.selectmenu", {
 			.toggleClass(self.widgetBaseClass + "-menu-dropdown ui-corner-bottom", isDropDown)
 			.toggleClass(self.widgetBaseClass + "-menu-popup ui-corner-all", !isDropDown)
 			// add corners to top and bottom menu items
-			.find('li:first')
+			.find(this.listItemSelector + ':first')
 			.toggleClass("ui-corner-top", !isDropDown)
-			.end().find('li:last')
+			.end().find(this.listItemSelector + ':last')
 			.addClass("ui-corner-bottom");
 		this.selectmenuIcon
 			.toggleClass('ui-icon-triangle-1-s', isDropDown)
@@ -413,7 +417,7 @@ $.widget("ui.selectmenu", {
 		}
 
 		// save reference to actionable li's (not group label li's)
-		this._optionLis = this.list.find('li:not(.' + self.widgetBaseClass + '-group)');
+		this._optionLis = this.list.find(this.listItemSelector + ':not(.' + self.widgetBaseClass + '-group)');
 						
 		// transfer disabled state
 		if (this.element.attr('disabled') === true) {
@@ -472,7 +476,7 @@ $.widget("ui.selectmenu", {
 				$(elem).trigger(eventType);
 				typeof(self._prevChar) == 'undefined' ? self._prevChar = [c] : self._prevChar[self._prevChar.length] = c;
 			}
-			this.list.find('li a').each(function(i) {	
+			this.list.find(this.listItemSelector + ' a').each(function(i) {
 				if (!focusFound) {
 					// allow the typeahead attribute on the option tag for a more specific lookup
 					var thisText = $(this).attr('typeahead') || $(this).text();
@@ -505,7 +509,7 @@ $.widget("ui.selectmenu", {
 				$(elem).trigger(eventType);
 				self._prevChar[1] = ind;
 			}
-			this.list.find('li a').each(function(i){	
+			this.list.find(this.listItemSelector + ' a').each(function(i){
 				if(!focusFound){
 					var thisText = $(this).text();
 					if( thisText.indexOf(C) == 0 || thisText.indexOf(c) == 0){
@@ -545,7 +549,7 @@ $.widget("ui.selectmenu", {
 			}
 			this.list.addClass(self.widgetBaseClass + '-open')
 				.attr('aria-hidden', false)
-				.find('li:not(.' + self.widgetBaseClass + '-group):eq(' + this._selectedIndex() + ') a')[0].focus();
+				.find(this.listItemSelector + ':not(.' + self.widgetBaseClass + '-group):eq(' + this._selectedIndex() + ') a')[0].focus();
 			if ( this.options.style == "dropdown" ) {
 				this.newelement.removeClass('ui-corner-all').addClass('ui-corner-top');
 			}
@@ -640,7 +644,7 @@ $.widget("ui.selectmenu", {
 	},
 
 	_scrollPage: function(direction) {
-		var numPerPage = Math.floor(this.list.outerHeight() / this.list.find('li:first').outerHeight());
+		var numPerPage = Math.floor(this.list.outerHeight() / this.list.find(this.listItemSelector + ':first').outerHeight());
 		numPerPage = (direction == 'up' ? -numPerPage : numPerPage);
 		this._moveFocus(numPerPage);
 	},

--- a/ui/jquery.ui.selectmenu.js
+++ b/ui/jquery.ui.selectmenu.js
@@ -166,7 +166,7 @@ $.widget("ui.selectmenu", {
 		this.element.hide();		
 
 		// create menu portion, append to body
-		this.list = $('<ul class="' + self.widgetBaseClass + '-menu ui-widget ui-widget-content" aria-hidden="true" role="listbox" aria-labelledby="' + this.ids[0] + '" id="' + this.ids[1] + '"></ul>').appendTo('body');
+		this.list = this._createListContainer().appendTo('body');
 		this.list.wrap(o.wrapperElement);				
 
 		// transfer menu click to menu button
@@ -231,6 +231,14 @@ $.widget("ui.selectmenu", {
 		// needed when window is resized
 		$(window).bind( "resize.selectmenu", $.proxy( self._refreshPosition, this ) );
 	},
+
+  /**
+   * Create container for list items
+   * @return HTMLElement
+   */
+  _createListContainer: function() {
+    return $('<ul class="' + this.widgetBaseClass + '-menu ui-widget ui-widget-content" aria-hidden="true" role="listbox" aria-labelledby="' + this.ids[0] + '" id="' + this.ids[1] + '"></ul>');
+  },
 
   /**
    * Get data for an option element

--- a/ui/jquery.ui.selectmenu.js
+++ b/ui/jquery.ui.selectmenu.js
@@ -15,10 +15,10 @@ $.widget("ui.selectmenu", {
 	getter: "value",
 	version: "1.8",
 	eventPrefix: "selectmenu",
-  listContainerSelector: 'ul',
   listContainerTag: 'ul',
-  listItemSelector: 'li',
+  listContainerSelector: null,
   listItemTag: 'li',
+  listItemSelector: null,
 	options: {
 		transferClasses: true,
 		typeAhead: "sequential",
@@ -40,6 +40,9 @@ $.widget("ui.selectmenu", {
 
 	_create: function() {
 		var self = this, o = this.options;
+
+    if(this.listItemSelector === null) this.listItemSelector = this.listItemTag;
+    if(this.listContainerSelector === null) this.listContainerSelector = this.listContainerTag;
 
 		// set a default id value, generate a new random one if not set by developer
 		var selectmenuId = this.element.attr('id') || 'ui-selectmenu-' + Math.random().toString(16).slice(2, 10);

--- a/ui/jquery.ui.selectmenu.js
+++ b/ui/jquery.ui.selectmenu.js
@@ -263,6 +263,29 @@ $.widget("ui.selectmenu", {
     return $('<li role="presentation"><a href="#" tabindex="-1" role="option" aria-selected="false"'+ (optionData.typeahead ? ' typeahead="' + optionData.typeahead + '"' : '' ) + '>'+ optionData.text +'</a></li>')
   },
 
+  /**
+   * Append new item to the list
+   * @param HTMLElement item Element created in _createListItem
+   * @param Object optionData Option data gained from _getOptionData
+   */
+  _appendItemToList: function(item, optionData) {
+    // optgroup or not...
+    if (optionData.parentOptGroup) {
+      // whitespace in the optgroupname must be replaced, otherwise the li of existing optgroups are never found
+      var optGroupName = this.widgetBaseClass + '-group-' + optionData.parentOptGroup.replace(/[^a-zA-Z0-9]/g, "");
+      if (this.list.find('li.' + optGroupName).size()) {
+        this.list.find('li.' + optGroupName + ':last ul').append(item);
+      } else {
+        $('<li role="presentation" class="' + self.widgetBaseClass + '-group ' + optGroupName + '"><span class="' + self.widgetBaseClass + '-group-label">' + optionData.parentOptGroup + '</span><ul></ul></li>')
+          .appendTo(this.list)
+          .find('ul')
+          .append(item);
+      }
+    } else {
+      item.appendTo(this.list);
+    }
+  },
+
 	_init: function() {
 		var self = this, o = this.options;
 		
@@ -313,21 +336,8 @@ $.widget("ui.selectmenu", {
 					$(this).removeClass(self.widgetBaseClass + '-item-focus ui-state-hover');
 				});
 
-			// optgroup or not...
-			if (selectOptionData[i].parentOptGroup) {
-				// whitespace in the optgroupname must be replaced, otherwise the li of existing optgroups are never found
-				var optGroupName = self.widgetBaseClass + '-group-' + selectOptionData[i].parentOptGroup.replace(/[^a-zA-Z0-9]/g, "");
-				if (this.list.find('li.' + optGroupName).size()) {
-					this.list.find('li.' + optGroupName + ':last ul').append(thisLi);
-				} else {
-					$('<li role="presentation" class="' + self.widgetBaseClass + '-group ' + optGroupName + '"><span class="' + self.widgetBaseClass + '-group-label">' + selectOptionData[i].parentOptGroup + '</span><ul></ul></li>')
-						.appendTo(this.list)
-						.find('ul')
-						.append(thisLi);
-				}
-			} else {
-				thisLi.appendTo(this.list);
-			}
+      // Append item to list
+      this._appendItemToList(thisLi, selectOptionData[i]);
 
 			// append icon if option is specified
 			if (o.icons) {

--- a/ui/jquery.ui.selectmenu.js
+++ b/ui/jquery.ui.selectmenu.js
@@ -224,7 +224,9 @@ $.widget("ui.selectmenu", {
 						self._typeAhead(event.keyCode,'focus');					break;	
 				}
 				return ret;
-			});			
+			})
+			// this allows for using the scrollbar in an overflowed list
+			.bind('mousedown.selectmenu mouseup.selectmenu', function() { return false; });
 		
 		// needed when window is resized
 		$(window).bind( "resize.selectmenu", $.proxy( self._refreshPosition, this ) );
@@ -303,10 +305,7 @@ $.widget("ui.selectmenu", {
 			} else {
 				thisLi.appendTo(this.list);
 			}
-			
-			// this allows for using the scrollbar in an overflowed list
-			this.list.bind('mousedown.selectmenu mouseup.selectmenu', function() { return false; });
-			
+
 			// append icon if option is specified
 			if (o.icons) {
 				for (var j in o.icons) {

--- a/ui/jquery.ui.selectmenu.js
+++ b/ui/jquery.ui.selectmenu.js
@@ -268,6 +268,13 @@ $.widget("ui.selectmenu", {
   },
 
   /**
+   * Clear all items in list
+   */
+  _clearList: function() {
+    this.list.html("");
+  },
+
+  /**
    * Creates list item to be appended to list
    * (allows for overriding this method)
    *
@@ -316,7 +323,7 @@ $.widget("ui.selectmenu", {
 		var activeClass = (self.options.style == "popup") ? " ui-state-active" : "";
 
 		// empty list so we can refresh the selectmenu via selectmenu()
-		this.list.html("");
+		this._clearList();
 
 		// write li's
 		for (var i = 0; i < selectOptionData.length; i++) {

--- a/ui/jquery.ui.selectmenu.js
+++ b/ui/jquery.ui.selectmenu.js
@@ -236,6 +236,9 @@ $.widget("ui.selectmenu", {
    * Get data for an option element
    * These data will be stored in selectOptionData array
    * (allows for overriding this method)
+   *
+   * @param HTMLElement option
+   * @return Object
    */
   _getOptionData: function(option) {
     return {
@@ -247,6 +250,17 @@ $.widget("ui.selectmenu", {
       parentOptGroup: $(option).parent('optgroup').attr('label'),
       bgImage: this.options.bgImage.call($(option))
     };
+  },
+
+  /**
+   * Creates list item to be appended to list
+   * (allows for overriding this method)
+   *
+   * @param Object optionData Data created in _getOptionData method
+   * @return HTMLElement
+   */
+  _createListItem: function(optionData) {
+    return $('<li role="presentation"><a href="#" tabindex="-1" role="option" aria-selected="false"'+ (optionData.typeahead ? ' typeahead="' + optionData.typeahead + '"' : '' ) + '>'+ optionData.text +'</a></li>')
   },
 
 	_init: function() {
@@ -268,7 +282,7 @@ $.widget("ui.selectmenu", {
 
 		// write li's
 		for (var i = 0; i < selectOptionData.length; i++) {
-					var thisLi = $('<li role="presentation"><a href="#" tabindex="-1" role="option" aria-selected="false"'+ (selectOptionData[i].typeahead ? ' typeahead="' + selectOptionData[i].typeahead + '"' : '' ) + '>'+ selectOptionData[i].text +'</a></li>')
+				var thisLi = this._createListItem(selectOptionData[i])
 				.data('index', i)
 				.addClass(selectOptionData[i].classes)
 				.data('optionClasses', selectOptionData[i].classes || '')


### PR DESCRIPTION
I did some refactoring to basic Selectmenu widget, so that it can be easily extended to show e.g. tables instead of a list. Sample of such extension: http://helemik.cz/juzna/opensource/js/jquery-ui/jquery.ui.selectmenu2.js

(see https://github.com/fnagel/jquery-ui/issues#issue/77)
