### PR TITLE
Autocomplete: keydown pulls value of list item, not label (description)

### DIFF
--- a/ui/jquery.ui.autocomplete.js
+++ b/ui/jquery.ui.autocomplete.js
@@ -160,7 +160,7 @@ $.widget( "ui.autocomplete", {
 					if ( false !== self._trigger( "focus", event, { item: item } ) ) {
 						// use value to match what will end up in the input, if it was a key event
 						if ( /^key/.test(event.originalEvent.type) ) {
-							self.element.val( item.value );
+							self.element.val( item.label );
 						}
 					}
 				},


### PR DESCRIPTION
If you're using the autocomplete widget and are using an external source that looks something like : [{"label":"Company", value:123456},{...] to populate your list, after typing a few characters (assuming your search yielded items) and pressing the down arrow, the keydown event substitutes the text in the textbox with the value of the list item, not the text. This minor change fixes that.
