### PR TITLE
Support for non-Latin typeahead

### DIFF
--- a/ui/jquery.ui.selectmenu.js
+++ b/ui/jquery.ui.selectmenu.js
@@ -766,7 +766,8 @@ $.widget("ui.selectmenu", {
 				of: o.positionOptions.of || this.newelement,
 				my: o.positionOptions.my,
 				at: o.positionOptions.at,
-				offset: o.positionOptions.offset || _offset
+				offset: o.positionOptions.offset || _offset,
+				collision: o.positionOptions.collision || 'flip'
 			});
 	}
 });

--- a/ui/jquery.ui.selectmenu.js
+++ b/ui/jquery.ui.selectmenu.js
@@ -123,10 +123,12 @@ $.widget("ui.selectmenu", {
 						break;
 					default:
 						ret = true;
-						self._typeAhead(event.keyCode, 'mouseup');
-						break;	
 				}
 				return ret;
+			})
+			.bind('keypress.selectmenu', function(event) {
+				self._typeAhead(event.which, 'mouseup');
+				return true;
 			})
 			.bind('mouseover.selectmenu focus.selectmenu', function() { 
 				if (!o.disabled) {
@@ -223,10 +225,12 @@ $.widget("ui.selectmenu", {
 						break;
 					default:
 						ret = true;	
-						self._typeAhead(event.keyCode,'focus');					
-						break;	
 				}
 				return ret;
+			})
+			.bind('keypress.selectmenu', function(event) {
+				self._typeAhead(event.which, 'focus');
+				return true;
 			});			
 		
 		// needed when window is resized
@@ -420,7 +424,7 @@ $.widget("ui.selectmenu", {
 	},
 
 	_typeAhead: function(code, eventType){
-		var self = this, focusFound = false, C = String.fromCharCode(code);
+		var self = this, focusFound = false, C = String.fromCharCode(code).toUpperCase();
 		c = C.toLowerCase();
 
 		if (self.options.typeAhead == 'sequential') {
@@ -440,7 +444,7 @@ $.widget("ui.selectmenu", {
 					// allow the typeahead attribute on the option tag for a more specific lookup
 					var thisText = $(this).attr('typeahead') || $(this).text();
 					if (thisText.indexOf(find+C) == 0) {
-						focusOptSeq(this,i, C)
+						focusOptSeq(this,i,C)
 					} else if (thisText.indexOf(find+c) == 0) {
 						focusOptSeq(this,i,c)
 					}

--- a/ui/jquery.ui.selectmenu.js
+++ b/ui/jquery.ui.selectmenu.js
@@ -157,11 +157,12 @@ $.widget("ui.selectmenu", {
 				}
 			});
 
-		// original selectmenu width
-		var selectWidth = this.element.width();
-
+		// set width when not set via options
+		if (!o.width) {
+			o.width = this.element.outerWidth();
+		}		
 		// set menu button width
-		this.newelement.width(o.width ? o.width : selectWidth);
+		this.newelement.width(o.width);
 
 		// hide original selectmenu element
 		this.element.hide();		
@@ -354,14 +355,11 @@ $.widget("ui.selectmenu", {
 			this.newelement.add(this.list).addClass(transferClasses);
 		}
 
-		// original selectmenu width
-		var selectWidth = this.element.width();
-
 		// set menu width to either menuWidth option value, width option value, or select width 
 		if (o.style == 'dropdown') { 
-			this.list.width(o.menuWidth ? o.menuWidth : (o.width ? o.width : selectWidth)); 
+			this.list.width(o.menuWidth ? o.menuWidth : o.width); 
 		} else { 
-			this.list.width(o.menuWidth ? o.menuWidth : (o.width ? o.width - o.handleWidth : selectWidth - o.handleWidth)); 
+			this.list.width(o.menuWidth ? o.menuWidth : o.width - o.handleWidth); 
 		}
 
 		// calculate default max height


### PR DESCRIPTION
I noticed that type ahead functionality doesn't work for Russian. The root of the problem is keyDown event. Here's some modifications to support non-Latin type ahead. Tested on Linux - Firefox, Opera and Chromium and Windows - Firefox. Please, review my fixes.
