### PR TITLE
Fix for IE8 focus issue when initializing with multiple selectmenu function calls

### DIFF
--- a/ui/jquery.ui.selectmenu.js
+++ b/ui/jquery.ui.selectmenu.js
@@ -441,9 +441,10 @@ $.widget("ui.selectmenu", {
 		this.index( this._selectedIndex() );
 
 		// needed when selectmenu is placed at the very bottom / top of the page
-		window.setTimeout( function() {
+		clearTimeout(this.refreshTimeout);
+		this.refreshTimeout = window.setTimeout(function () {
 			self._refreshPosition();
-		}, 200 );
+		}, 200);
 	},
 
 	destroy: function() {


### PR DESCRIPTION
Hi Felix,

This is the fix for the issue I alluded to in Issue #191. Basically, if you make multiple selectmenu calls on a single element, the timeout for the _refreshPosition call would be done as many times as you call it. This was causing issues in IE8 where clicking the dropdown would throw the following error:
"Can't move focus to the control because it is invisible, not enabled, or of a type that does not accept the focus."

Saving the timeout reference and clearing it before creating a new one resolves the issue.

Thanks!

Travis

p.s. This is my first git commit and pull request, hopefully I did it correctly.
