### PR TITLE
Fix an Operation Aborted issue with IE 7/8 where the menu is called inline. 

### DIFF
--- a/ui/jquery.ui.selectmenu.js
+++ b/ui/jquery.ui.selectmenu.js
@@ -194,10 +194,15 @@ $.widget("ui.selectmenu", {
 			'aria-labelledby': this.ids[1],
 			'id': this.ids[2]
 		});
-		this.listWrap = $( o.wrapperElement )
-			.addClass( self.widgetBaseClass + '-menu' )
-			.append( this.list )
-			.appendTo( 'body' );
+        this.listWrap = $( o.wrapperElement ).addClass( self.widgetBaseClass + '-menu' ).append( this.list );
+        // If this code is called inline (instead of via jQuery.ready), 
+        // the body isn't ready yet, IE 7 will throw an Operation Aborted error,
+        // and IE 8 will throw a js error
+        // So we append it to the body when the document is ready
+        var laterWrap = this.listWrap;
+        $(document).ready(function() {
+            $("body").append(laterWrap);
+        });
 		
 		// transfer menu click to menu button
 		this.list


### PR DESCRIPTION
Since the body isn't closed yet, IE 7/8 barfs if this is called inline instead of via $(document).ready(). More information on why Microsoft doesn't allow you to append to elements before they are closed: See http://support.microsoft.com/kb/927917

Note that this is fixed in IE 9, and does not show up when using the IE 7/8 compatibility mode. You must be running the actual IE 7/8. 

Simple use case to replicate: http://pastebin.com/7sgERvpN

This patch fixes the problem by delaying the appending of the hidden ul list to the body until _after_ document.ready(), and it solved our problems.
