### PR TITLE
enhance `format` option by passing entire option element to function

### DIFF
--- a/ui/jquery.ui.selectmenu.js
+++ b/ui/jquery.ui.selectmenu.js
@@ -280,7 +280,7 @@ $.widget("ui.selectmenu", {
 			var opt = $(this);
 			selectOptionData.push({
 				value: opt.attr('value'),
-				text: self._formatText(opt.text()),
+				text: self._formatText(opt),
 				selected: opt.attr('selected'),
 				disabled: opt.attr('disabled'),
 				classes: opt.attr('class'),
@@ -623,9 +623,9 @@ $.widget("ui.selectmenu", {
 		}
 	},
 
-	_formatText: function(text) {
+	_formatText: function(opt) {
 		if (this.options.format) {
-			text = this.options.format(text);
+			text = this.options.format(opt.text(), opt);
 		} else if (this.options.escapeHtml) {
 			text = $('<div />').text(text).html();
 		}


### PR DESCRIPTION
instead of just passing the text, give the formatter function a reference to the
entire option element during construction. 

Still passing opt.text() as the first argument to preserve backwards compatibility, although this is now superfluous it does not seem worth it to break existing apps.

An example of why this is needed is in my use case which uses `data-` attributes from the original option elements to make the options look fancy:

```
$('#product_options select.calculatable').selectmenu({format : function(text, opt) {
            return opt.text()
                   + '<span class="price">'
                   + format_price($(opt).data('adder'))
                   + '</span>';
 }});
```
